### PR TITLE
add pfs service tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,16 @@ version: 2.1
 
 jobs:
   test:
-    docker:
-      - image: circleci/node:14.16.0
+    machine:
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
       - run: npm ci
       - run: npm run lint
-      - run: npm run test
+      - run: etc/testing/circle/install.sh
+      - run: etc/testing/circle/start-minikube.sh
+      - run: etc/testing/circle/deploy-pachyderm.sh
+      - run: pachctl port-forward & npm run test
 workflows:
   version: 2
   test:

--- a/etc/testing/circle/deploy-pachyderm.sh
+++ b/etc/testing/circle/deploy-pachyderm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
+
+helm repo add pachyderm https://pachyderm.github.io/helmchart
+helm repo update
+helm install pachd pachyderm/pachyderm --set deployTarget=LOCAL --version ${PACHYDERM_VERSION}
+
+kubectl wait --for=condition=available deployment -l app=pachd --timeout=5m
+pachctl version

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p cached-deps
+
+# Install deps
+sudo apt update -y
+sudo apt-get install -y -qq \
+  pkg-config \
+  conntrack
+
+# Install Helm
+curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+sudo apt-get install apt-transport-https --yes
+echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt-get update
+sudo apt-get install helm
+
+# Install kubectl
+# To get the latest kubectl version:
+# curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+if [ ! -f cached-deps/kubectl ] ; then
+    KUBECTL_VERSION="v$(jq -r .kubernetes version.json)"
+    curl -L -o kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+        chmod +x ./kubectl
+        mv ./kubectl cached-deps/kubectl
+fi
+
+# Install minikube
+# To get the latest minikube version:
+# curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort -V | tail -n1
+if [ ! -f cached-deps/minikube ] ; then
+    MINIKUBE_VERSION="v$(jq -r .minikube version.json)"
+    curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
+        chmod +x ./minikube
+        mv ./minikube cached-deps/minikube
+fi
+
+export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
+
+# Install Pachyderm
+curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
+sudo dpkg -i /tmp/pachctl.deb

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+
+# Parse flags
+KUBE_VERSION="$( jq -r .kubernetes <"$(git rev-parse --show-toplevel)/version.json" )"
+minikube_args=(
+  "--vm-driver=docker"
+  "--kubernetes-version=${KUBE_VERSION}"
+)
+while getopts ":v" opt; do
+  case "${opt}" in
+    v)
+      KUBE_VERSION="v${OPTARG}"
+      ;;
+    \?)
+      echo "Invalid argument: ${opt}"
+      exit 1
+      ;;
+  esac
+done
+
+minikube start "${minikube_args[@]}"
+
+# Try to connect for three minutes
+for _ in $(seq 36); do
+  if kubectl version &>/dev/null; then
+    exit 0
+  fi
+  sleep 5
+done
+
+# Give up--kubernetes isn't coming up
+minikube delete
+sleep 30 # Wait for minikube to go completely down
+exit 1

--- a/src/builders/pfs.ts
+++ b/src/builders/pfs.ts
@@ -94,10 +94,10 @@ export type SubscribeCommitRequestObject = {
 };
 
 export type CreateBranchRequestObject = {
-  head: CommitObject;
-  branch: BranchObject;
+  head?: CommitObject;
+  branch?: BranchObject;
   provenance: BranchObject[];
-  trigger: TriggerObject;
+  trigger?: TriggerObject;
   newCommitSet: CreateBranchRequest.AsObject['newCommitSet'];
 };
 
@@ -371,13 +371,13 @@ export const createBranchRequestFromObject = ({
   head,
   branch,
   trigger,
-  provenance = [],
-  newCommitSet = false,
+  provenance,
+  newCommitSet,
 }: CreateBranchRequestObject) => {
   const request = new CreateBranchRequest();
 
-  request.setHead(commitFromObject(head));
-  request.setBranch(branchFromObject(branch));
+  if (head) request.setHead(commitFromObject(head));
+  if (branch) request.setBranch(branchFromObject(branch));
 
   if (provenance) {
     const provenanceArray: Branch[] = provenance.map((eachProvenanceObject) => {
@@ -386,7 +386,7 @@ export const createBranchRequestFromObject = ({
     request.setProvenanceList(provenanceArray);
   }
 
-  request.setTrigger(triggerFromObject(trigger));
+  if (trigger) request.setTrigger(triggerFromObject(trigger));
   request.setNewCommitSet(newCommitSet);
 
   return request;
@@ -398,7 +398,7 @@ export const listBranchRequestFromObject = ({
 }: ListBranchRequestObject) => {
   const request = new ListBranchRequest();
 
-  request.setRepo(new Repo().setName(repo.name || '').setType('user'));
+  request.setRepo(new Repo().setName(repo?.name || '').setType('user'));
   request.setReverse(reverse);
 
   return request;

--- a/src/services/__tests__/pfs.test.ts
+++ b/src/services/__tests__/pfs.test.ts
@@ -1,0 +1,251 @@
+import client from 'client';
+
+describe('services/pfs', () => {
+  afterAll(async () => {
+    const pachClient = client({ssl: false, pachdAddress: 'localhost:30650'});
+    const pfs = pachClient.pfs();
+    await pfs.deleteAll();
+  });
+  const createSandbox = async (name: string) => {
+    const pachClient = client({ssl: false, pachdAddress: 'localhost:30650'});
+    const pfs = pachClient.pfs();
+    await pfs.deleteAll();
+    await pfs.createRepo({repo: {name}});
+
+    return pachClient;
+  };
+  describe('listFile', () => {
+    it('should return a list of files in the directory', async () => {
+      // TODO Implement putFile
+    });
+  });
+
+  describe('getFile', () => {
+    it('should get the specified file', async () => {
+      // TODO Implement putFile
+    });
+  });
+  describe('inspectFile', () => {
+    it('should return details about the specified file', async () => {
+      // TODO Implement putFile
+    });
+  });
+  describe('listCommit', () => {
+    it('should list the commits for the specified repo', async () => {
+      const client = await createSandbox('listCommit');
+      const commit = await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'listCommit'}}});
+      await client.pfs().finishCommit({commit});
+      await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'listCommit'}}});
+
+      const commits = await client
+        .pfs()
+        .listCommit({repo: {name: 'listCommit'}});
+
+      expect(commits).toHaveLength(2);
+    });
+    it('should return only the specified number of commits if number is specified', async () => {
+      const client = await createSandbox('listCommit');
+      const commit = await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'listCommit'}}});
+      await client.pfs().finishCommit({commit});
+      await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'listCommit'}}});
+
+      const commits = await client
+        .pfs()
+        .listCommit({repo: {name: 'listCommit'}, number: 1});
+
+      expect(commits).toHaveLength(1);
+    });
+  });
+  describe('inspectCommitSet', () => {
+    it('should return details about a commit set', async () => {
+      const client = await createSandbox('inspectCommitSet');
+      const commit = await client.pfs().startCommit({
+        branch: {name: 'master', repo: {name: 'inspectCommitSet'}},
+      });
+      await client.pfs().finishCommit({commit});
+      const commitSet = await client
+        .pfs()
+        .inspectCommitSet({commitSet: commit});
+
+      expect(commitSet).toHaveLength(1);
+      expect(commitSet[0].error).toBeFalsy();
+      expect(commitSet[0].details?.sizeBytes).toEqual(0);
+    });
+  });
+  describe('listCommitSet', () => {
+    it('should list the commit sets', async () => {
+      const client = await createSandbox('listCommitSet');
+      const commit = await client.pfs().startCommit({
+        branch: {name: 'master', repo: {name: 'listCommitSet'}},
+      });
+      await client.pfs().finishCommit({commit});
+
+      const commitSets = await client.pfs().listCommitSet();
+      expect(commitSets).toHaveLength(1);
+    });
+  });
+  describe('squashCommitSet', () => {
+    it('should squash commits', async () => {
+      const client = await createSandbox('squashCommitSet');
+      const commit1 = await client.pfs().startCommit({
+        branch: {name: 'master', repo: {name: 'squashCommitSet'}},
+      });
+      await client.pfs().finishCommit({commit: commit1});
+      const commit2 = await client.pfs().startCommit({
+        branch: {name: 'master', repo: {name: 'squashCommitSet'}},
+      });
+      await client.pfs().finishCommit({commit: commit2});
+
+      const commits = await client
+        .pfs()
+        .listCommit({repo: {name: 'squashCommitSet'}});
+
+      expect(commits).toHaveLength(2);
+
+      await client.pfs().squashCommitSet(commit1);
+
+      const updatedCommits = await client
+        .pfs()
+        .listCommit({repo: {name: 'squashCommitSet'}});
+
+      expect(updatedCommits).toHaveLength(1);
+    });
+  });
+  describe('createBranch', () => {
+    it('should create a branch', async () => {
+      const client = await createSandbox('createBranch');
+
+      const commit = await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'createBranch'}}});
+
+      await client.pfs().createBranch({
+        newCommitSet: false,
+        head: commit,
+        provenance: [],
+        branch: {name: 'test', repo: {name: 'createBranch'}},
+      });
+      const updatedBranches = await client
+        .pfs()
+        .listBranch({repo: {name: 'createBranch'}});
+
+      expect(updatedBranches).toHaveLength(2);
+      expect(updatedBranches[0].branch?.name).toEqual('test');
+    });
+  });
+  describe('inspectBranch', () => {
+    it('should return details about a branch', async () => {
+      const client = await createSandbox('inspectBranch');
+      await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'inspectBranch'}}});
+      const branch = await client
+        .pfs()
+        .inspectBranch({name: 'master', repo: {name: 'inspectBranch'}});
+
+      expect(branch.branch?.name).toEqual('master');
+      expect(branch.head?.branch?.name).toEqual('master');
+      expect(branch.provenanceList).toHaveLength(0);
+      expect(branch.subvenanceList).toHaveLength(0);
+      expect(branch.directProvenanceList).toHaveLength(0);
+    });
+  });
+  describe('listBranch', () => {
+    it('should return a list of branches', async () => {
+      const client = await createSandbox('listBranch');
+      await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'listBranch'}}});
+      const branches = await client
+        .pfs()
+        .listBranch({repo: {name: 'listBranch'}});
+      expect(branches).toHaveLength(1);
+
+      expect(branches).toHaveLength(1);
+      expect(branches[0].branch?.name).toEqual('master');
+      expect(branches[0].provenanceList).toHaveLength(0);
+      expect(branches[0].subvenanceList).toHaveLength(0);
+    });
+  });
+  describe('deleteBranch', () => {
+    it('should delete branch', async () => {
+      const client = await createSandbox('deleteBranch');
+      const initialBranches = await client
+        .pfs()
+        .listBranch({repo: {name: 'deleteBranch'}});
+      expect(initialBranches).toHaveLength(0);
+
+      await client
+        .pfs()
+        .startCommit({branch: {name: 'master', repo: {name: 'deleteBranch'}}});
+
+      const updatedBranches = await client
+        .pfs()
+        .listBranch({repo: {name: 'deleteBranch'}});
+
+      expect(updatedBranches).toHaveLength(1);
+
+      await client
+        .pfs()
+        .deleteBranch({branch: {name: 'master', repo: {name: 'deleteBranch'}}});
+
+      const finalBranches = await client
+        .pfs()
+        .listBranch({repo: {name: 'deleteBranch'}});
+
+      expect(finalBranches).toHaveLength(0);
+    });
+  });
+  describe('listRepo', () => {
+    it('should return a list of all repos in the cluster', async () => {
+      const client = await createSandbox('listRepo');
+      const repos = await client.pfs().listRepo();
+
+      expect(repos).toHaveLength(1);
+    });
+  });
+  describe('inspectRepo', () => {
+    it('should return information about the specified', async () => {
+      const client = await createSandbox('inspectRepo');
+      const repo = await client.pfs().inspectRepo('inspectRepo');
+
+      expect(repo.repo?.name).toEqual('inspectRepo');
+      expect(repo.repo?.type).toEqual('user');
+      expect(repo.branchesList).toHaveLength(0);
+    });
+  });
+  describe('createRepo', () => {
+    it('should create a repo', async () => {
+      const client = await createSandbox('createRepo');
+
+      const initialRepos = await client.pfs().listRepo();
+      expect(initialRepos).toHaveLength(1);
+
+      await client.pfs().createRepo({repo: {name: 'anotherRepo'}});
+
+      const udatedRepos = await client.pfs().listRepo();
+      expect(udatedRepos).toHaveLength(2);
+    });
+  });
+  describe('deleteRepo', () => {
+    it('should delete a repo', async () => {
+      const client = await createSandbox('deleteRepo');
+
+      const initialRepos = await client.pfs().listRepo();
+      expect(initialRepos).toHaveLength(1);
+
+      await client.pfs().deleteRepo({repo: {name: 'deleteRepo'}});
+
+      const updatedRepos = await client.pfs().listRepo();
+      expect(updatedRepos).toHaveLength(0);
+    });
+  });
+});

--- a/src/services/pfs.ts
+++ b/src/services/pfs.ts
@@ -359,6 +359,16 @@ const pfs = ({
         });
       });
     },
+    deleteAll: () => {
+      return new Promise<Empty.AsObject>((resolve, reject) => {
+        client.deleteAll(new Empty(), (error) => {
+          if (error) {
+            return reject(error);
+          }
+          return resolve({});
+        });
+      });
+    },
   };
 };
 

--- a/src/services/pps.ts
+++ b/src/services/pps.ts
@@ -14,6 +14,7 @@ import {
   ListJobSetRequest,
   JobSetInfo,
 } from '@pachyderm/proto/pb/pps/pps_pb';
+import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
 
 import {
   jobFromObject,
@@ -150,6 +151,17 @@ const pps = ({
           }
         },
       );
+    },
+
+    deleteAll: () => {
+      return new Promise<Empty.AsObject>((resolve, reject) => {
+        client.deleteAll(new Empty(), (error) => {
+          if (error) {
+            return reject(error);
+          }
+          return resolve({});
+        });
+      });
     },
   };
 };

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+  "pachyderm": "2.0.0-beta.4",
+  "kubernetes": "1.21.0",
+  "minikube": "1.22.0"
+}


### PR DESCRIPTION
Adds tests for `services/pfs` that run against a minikube cluster. We'll need to implement `putFile` before we can test the file methods and we'll also need to implement `createPipeline` for the pps tests.