### PR TITLE
initial pps tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest --max-workers=6",
+    "test": "jest --max-workers=1",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "build": "npm run clean && npm run build:src && npm run build:types",
     "build:src": "tsc -p tsconfig.json",

--- a/src/services/__tests__/pps.test.ts
+++ b/src/services/__tests__/pps.test.ts
@@ -1,0 +1,147 @@
+import crypto from 'crypto';
+
+import {
+  Input,
+  PFSInput,
+  PipelineState,
+  Transform,
+} from '@pachyderm/proto/pb/pps/pps_pb';
+
+import client from 'client';
+
+describe('services/pps', () => {
+  afterAll(async () => {
+    const pachClient = client({ssl: false, pachdAddress: 'localhost:30650'});
+    const pps = pachClient.pps();
+    await pps.deleteAll();
+  });
+
+  const createSandBox = async (name: string) => {
+    const pachClient = client({ssl: false, pachdAddress: 'localhost:30650'});
+    const pps = pachClient.pps();
+    const pfs = pachClient.pfs();
+    await pps.deleteAll();
+    await pfs.deleteAll();
+    const inputRepoName = crypto.randomBytes(5).toString('hex');
+    await pfs.createRepo({repo: {name: inputRepoName}});
+    const transform = new Transform()
+      .setCmdList(['sh'])
+      .setImage('alpine')
+      .setStdinList([`cp /pfs/${inputRepoName}/*.dat /pfs/out/`]);
+    const input = new Input();
+    const pfsInput = new PFSInput().setGlob('/*').setRepo(inputRepoName);
+    input.setPfs(pfsInput);
+
+    await pps.createPipeline({
+      name,
+      transform: transform.toObject(),
+      input: input.toObject(),
+    });
+
+    return {pachClient, inputRepoName};
+  };
+
+  describe('listPipeline', () => {
+    it('should return a list of pipelines in the pachyderm cluster', async () => {
+      const {pachClient} = await createSandBox('listPipeline');
+
+      const pipelines = await pachClient.pps().listPipeline();
+
+      expect(pipelines).toHaveLength(1);
+      expect(pipelines[0].pipeline?.name).toEqual('listPipeline');
+    });
+  });
+
+  describe('listJobs', () => {
+    it('should return a list of jobs', async () => {
+      const {pachClient} = await createSandBox('listJobs');
+
+      const jobs = await pachClient.pps().listJobs();
+      expect(jobs).toHaveLength(1);
+    });
+  });
+
+  describe('inspectPipeline', () => {
+    it('should return details about the pipeline', async () => {
+      const {pachClient, inputRepoName} = await createSandBox(
+        'inspectPipeline',
+      );
+
+      const pipeline = await pachClient
+        .pps()
+        .inspectPipeline('inspectPipeline');
+
+      expect(pipeline.pipeline?.name).toEqual('inspectPipeline');
+      expect(pipeline.state).toEqual(PipelineState.PIPELINE_STARTING);
+      expect(pipeline.details?.input?.pfs?.repo).toEqual(inputRepoName);
+    });
+  });
+
+  describe('listJobSets', () => {
+    it('should return a list of job sets', async () => {
+      const {pachClient} = await createSandBox('listJobSets');
+
+      const jobSets = await pachClient.pps().listJobSets();
+      expect(jobSets).toHaveLength(1);
+    });
+  });
+
+  describe('inspectJob', () => {
+    it('should return details about the specified job', async () => {
+      const {pachClient} = await createSandBox('inspectJob');
+      const jobs = await pachClient.pps().listJobs();
+      const job = await pachClient.pps().inspectJob({
+        id: jobs[0].job?.id || '',
+        pipelineName: 'inspectJob',
+        projectId: '',
+      });
+
+      expect(job).toMatchObject(jobs[0]);
+    });
+  });
+
+  describe('getLogs', () => {
+    it('should return logs about the cluster', async () => {
+      const {pachClient} = await createSandBox('getLogs');
+      const logs = await pachClient.pps().getLogs({});
+      logs.map((log) =>
+        expect(log).toEqual(
+          expect.objectContaining({
+            pipelineName: expect.any(String),
+            jobId: expect.any(String),
+            workerId: expect.any(String),
+            datumId: expect.any(String),
+            master: expect.any(Boolean),
+            dataList: expect.any(Array),
+            user: expect.any(Boolean),
+            message: expect.any(String),
+          }),
+        ),
+      );
+    });
+  });
+
+  describe('createPipeline', () => {
+    it('should create a pipeline', async () => {
+      const {pachClient, inputRepoName} = await createSandBox('createPipeline');
+      const pipelines = await pachClient.pps().listPipeline();
+      expect(pipelines).toHaveLength(1);
+
+      const transform = new Transform()
+        .setCmdList(['sh'])
+        .setImage('alpine')
+        .setStdinList([`cp /pfs/${inputRepoName}/*.dat /pfs/out/`]);
+      const input = new Input();
+      const pfsInput = new PFSInput().setGlob('/*').setRepo(inputRepoName);
+      input.setPfs(pfsInput);
+
+      await pachClient.pps().createPipeline({
+        name: 'createPipeline2',
+        transform: transform.toObject(),
+        input: input.toObject(),
+      });
+      const updatedPipelines = await pachClient.pps().listPipeline();
+      expect(updatedPipelines).toHaveLength(2);
+    });
+  });
+});

--- a/src/services/pps.ts
+++ b/src/services/pps.ts
@@ -13,14 +13,29 @@ import {
   Pipeline,
   ListJobSetRequest,
   JobSetInfo,
+  CreatePipelineRequest,
+  Transform,
+  Input,
 } from '@pachyderm/proto/pb/pps/pps_pb';
 import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
+
+import {commitFromObject} from 'builders/pfs';
+import {durationFromObject} from 'builders/protobuf';
 
 import {
   jobFromObject,
   pipelineFromObject,
   GetLogsRequestObject,
   getLogsRequestFromObject,
+  egressFromObject,
+  inputFromObject,
+  parallelismSpecFromObject,
+  chunkSpecFromObject,
+  resourceSpecFromObject,
+  schedulingSpecFromObject,
+  serviceFromObject,
+  spoutFromObject,
+  transformFromObject,
 } from '../builders/pps';
 import {JobSetQueryArgs, JobQueryArgs, ServiceArgs} from '../lib/types';
 import {DEFAULT_JOBS_LIMIT} from '../services/constants/pps';
@@ -33,6 +48,41 @@ export interface ListJobArgs extends ListArgs {
   pipelineId?: string | null;
 }
 
+interface CreatePipelineRequestOptions
+  extends Omit<
+    CreatePipelineRequest.AsObject,
+    | 'autoscaling'
+    | 'pipeline'
+    | 'description'
+    | 'transform'
+    | 'podPatch'
+    | 'podSpec'
+    | 'outputBranch'
+    | 'reprocess'
+    | 'reprocessSpec'
+    | 'tfJob'
+    | 'extension'
+    | 'update'
+    | 'salt'
+    | 's3Out'
+    | 'datumTries'
+  > {
+  autoscaling?: CreatePipelineRequest.AsObject['autoscaling'];
+  name: string;
+  transform: Transform.AsObject;
+  description?: CreatePipelineRequest.AsObject['description'];
+  input: Input.AsObject;
+  podPatch?: CreatePipelineRequest.AsObject['podPatch'];
+  podSpec?: CreatePipelineRequest.AsObject['podSpec'];
+  outputBranch?: CreatePipelineRequest.AsObject['outputBranch'];
+  reprocess?: CreatePipelineRequest.AsObject['reprocess'];
+  reprocessSpec?: CreatePipelineRequest.AsObject['reprocessSpec'];
+  update?: CreatePipelineRequest.AsObject['update'];
+  salt?: CreatePipelineRequest.AsObject['salt'];
+  s3Out?: CreatePipelineRequest.AsObject['s3Out'];
+  datumTries?: CreatePipelineRequest.AsObject['datumTries'];
+}
+
 const pps = ({
   pachdAddress,
   channelCredentials,
@@ -41,6 +91,64 @@ const pps = ({
   const client = new APIClient(pachdAddress, channelCredentials);
 
   return {
+    createPipeline: (options: CreatePipelineRequestOptions) => {
+      const request = new CreatePipelineRequest();
+      if (options.autoscaling) request.setAutoscaling(options.autoscaling);
+      if (options.datumSetSpec)
+        request.setDatumSetSpec(chunkSpecFromObject(options.datumSetSpec));
+      if (options.datumTimeout)
+        request.setDatumTimeout(durationFromObject(options.datumTimeout));
+      if (options.datumTries) request.setDatumTries(options.datumTries);
+      if (options.description) request.setDescription(options.description);
+      if (options.egress) request.setEgress(egressFromObject(options.egress));
+      if (options.input) request.setInput(inputFromObject(options.input));
+      if (options.jobTimeout)
+        request.setJobTimeout(durationFromObject(options.jobTimeout));
+      // if (options.metadata) request.setMetadata(options.metadata);
+      if (options.outputBranch) request.setOutputBranch(options.outputBranch);
+      if (options.parallelismSpec)
+        request.setParallelismSpec(
+          parallelismSpecFromObject(options.parallelismSpec),
+        );
+      request.setPipeline(pipelineFromObject({name: options.name}));
+      if (options.podPatch) request.setPodPatch(options.podPatch);
+      if (options.podSpec) request.setPodSpec(options.podSpec);
+      if (options.s3Out) request.setS3Out(options.s3Out);
+      if (options.reprocess) request.setReprocess(options.reprocess);
+      if (options.reprocessSpec)
+        request.setReprocessSpec(options.reprocessSpec);
+      if (options.resourceLimits)
+        request.setResourceLimits(
+          resourceSpecFromObject(options.resourceLimits),
+        );
+      if (options.resourceRequests)
+        request.setResourceRequests(
+          resourceSpecFromObject(options.resourceRequests),
+        );
+      if (options.schedulingSpec)
+        request.setSchedulingSpec(
+          schedulingSpecFromObject(options.schedulingSpec),
+        );
+      if (options.service)
+        request.setService(serviceFromObject(options.service));
+      if (options.sidecarResourceLimits)
+        request.setSidecarResourceLimits(
+          resourceSpecFromObject(options.sidecarResourceLimits),
+        );
+      if (options.spout) request.setSpout(spoutFromObject(options.spout));
+      if (options.update) request.setUpdate(options.update);
+      request.setTransform(transformFromObject(options.transform));
+      if (options.salt) request.setSalt(options.salt);
+      if (options.specCommit)
+        request.setSpecCommit(commitFromObject(options.specCommit));
+
+      return new Promise<Empty.AsObject>((resolve, reject) => {
+        client.createPipeline(request, (error) => {
+          if (error) return reject(error);
+          return resolve({});
+        });
+      });
+    },
     listPipeline: (jq = '') => {
       const listPipelineRequest = new ListPipelineRequest()
         .setJqfilter(jq)


### PR DESCRIPTION
Adds in initial PPS tests to node client. In a future PR we'll need to build out the interface to upload files to pfs from the client which will allow us to test logs and jobs more thoroughly.