### PR TITLE
fix: export CreatePipelineRequestOptions

### DIFF
--- a/src/services/pps.ts
+++ b/src/services/pps.ts
@@ -48,7 +48,7 @@ export interface ListJobArgs extends ListArgs {
   pipelineId?: string | null;
 }
 
-interface CreatePipelineRequestOptions
+export interface CreatePipelineRequestOptions
   extends Omit<
     CreatePipelineRequest.AsObject,
     | 'autoscaling'


### PR DESCRIPTION
This TS error was popping up when trying to publish to npm.

![image](https://user-images.githubusercontent.com/7471542/129928569-61616b56-4e22-4f1e-8fd6-50c32ec70c48.png)
