### PR TITLE
fix(commit): wait for commits to finish before squashing

### DIFF
--- a/src/services/__tests__/pfs.test.ts
+++ b/src/services/__tests__/pfs.test.ts
@@ -1,3 +1,5 @@
+import {CommitState} from '@pachyderm/proto/pb/pfs/pfs_pb';
+
 import client from 'client';
 
 describe('services/pfs', () => {
@@ -103,6 +105,12 @@ describe('services/pfs', () => {
         branch: {name: 'master', repo: {name: 'squashCommitSet'}},
       });
       await client.pfs().finishCommit({commit: commit2});
+      await client
+        .pfs()
+        .inspectCommit({commit: commit1, wait: CommitState.FINISHED});
+      await client
+        .pfs()
+        .inspectCommit({commit: commit2, wait: CommitState.FINISHED});
 
       const commits = await client
         .pfs()

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "pachyderm": "2.0.0-beta.5",
+  "pachyderm": "2.0.0-beta.6",
   "kubernetes": "1.21.0",
   "minikube": "1.22.0"
 }


### PR DESCRIPTION
I didn't ever update the version to beta 6, so this passed CI and I didn't notice until I tried to release locally using beta 6. 

It looks like beta 6 requires commits to be in the finished state before they are squashed, so we have to explicitly call inspectCommit and pass the wait flag before calling squashCommitSet.