### PR TITLE
Passing nano values from timestamp to jobInfo proto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/builders/__tests__/pps.test.ts
+++ b/src/builders/__tests__/pps.test.ts
@@ -572,15 +572,15 @@ it('should create JobInfo from an object', () => {
     job: {id: '1', pipeline: {name: 'montage'}},
     createdAt: {
       seconds: 564645,
-      nanos: 0,
+      nanos: 564645000000000,
     },
     startedAt: {
       seconds: 10000,
-      nanos: 0,
+      nanos: 10000000000000,
     },
     finishedAt: {
       seconds: 20000,
-      nanos: 0,
+      nanos: 20000000000000,
     },
     outputCommit: {
       branch: {
@@ -616,8 +616,11 @@ it('should create JobInfo from an object', () => {
   expect(pipelineJob.getState()).toBe(1);
   expect(pipelineJob.getReason()).toBe('everything broke');
   expect(pipelineJob.getCreated()?.getSeconds()).toBe(564645);
+  expect(pipelineJob.getCreated()?.getNanos()).toBe(564645000000000);
   expect(pipelineJob.getStarted()?.getSeconds()).toBe(10000);
+  expect(pipelineJob.getStarted()?.getNanos()).toBe(10000000000000);
   expect(pipelineJob.getFinished()?.getSeconds()).toBe(20000);
+  expect(pipelineJob.getFinished()?.getNanos()).toBe(20000000000000);
   expect(pipelineJob.getJob()?.getId()).toBe('1');
   expect(pipelineJob.getOutputCommit()?.getBranch()?.getName()).toBe(
     'development',

--- a/src/builders/pps.ts
+++ b/src/builders/pps.ts
@@ -631,19 +631,28 @@ export const jobInfoFromObject = ({
 
   if (createdAt) {
     jobInfo.setCreated(
-      timestampFromObject({seconds: createdAt?.seconds || 0, nanos: 0}),
+      timestampFromObject({
+        seconds: createdAt?.seconds || 0,
+        nanos: createdAt?.nanos || 0,
+      }),
     );
   }
 
   if (startedAt) {
     jobInfo.setStarted(
-      timestampFromObject({seconds: startedAt?.seconds || 0, nanos: 0}),
+      timestampFromObject({
+        seconds: startedAt?.seconds || 0,
+        nanos: startedAt?.nanos || 0,
+      }),
     );
   }
 
   if (finishedAt) {
     jobInfo.setFinished(
-      timestampFromObject({seconds: finishedAt?.seconds || 0, nanos: 0}),
+      timestampFromObject({
+        seconds: finishedAt?.seconds || 0,
+        nanos: finishedAt?.nanos || 0,
+      }),
     );
   }
 


### PR DESCRIPTION
We were incorrectly defaulting all of these to 0.

From a console perspective, we need this as we should be sorting subjobs by nanoseconds as opposed to seconds. Inputs that have several splits/joins/crosses have an opportunity for pipelines downstream to be "started" at the exact same millisecond.