### PR TITLE
fix(ts): update relative paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/builders/pps.ts
+++ b/src/builders/pps.ts
@@ -24,8 +24,6 @@ import {
   ProcessStats,
 } from '@pachyderm/proto/pb/pps/pps_pb';
 
-import {GetLogsRequestArgs} from 'lib/types';
-
 import {
   commitFromObject,
   CommitObject,
@@ -38,6 +36,7 @@ import {
   timestampFromObject,
   TimestampObject,
 } from '../builders/protobuf';
+import {GetLogsRequestArgs} from '../lib/types';
 
 export type PipelineObject = {
   name: Pipeline.AsObject['name'];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,7 +20,7 @@ import {
   CommitSetObject,
   RepoObject,
   TriggerObject,
-} from 'builders/pfs';
+} from '../builders/pfs';
 
 export interface GRPCPlugin {
   onCall?: (args: {requestName: string}) => void;

--- a/src/services/__tests__/ModifyFile.test.ts
+++ b/src/services/__tests__/ModifyFile.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import client from 'client';
+import client from '../../client';
 
 describe('ModifyFile', () => {
   afterAll(async () => {

--- a/src/services/__tests__/pfs.test.ts
+++ b/src/services/__tests__/pfs.test.ts
@@ -1,6 +1,6 @@
 import {CommitState, FileType} from '@pachyderm/proto/pb/pfs/pfs_pb';
 
-import client from 'client';
+import client from '../../client';
 
 describe('services/pfs', () => {
   afterAll(async () => {

--- a/src/services/__tests__/pps.test.ts
+++ b/src/services/__tests__/pps.test.ts
@@ -7,7 +7,7 @@ import {
   Transform,
 } from '@pachyderm/proto/pb/pps/pps_pb';
 
-import client from 'client';
+import client from '../../client';
 
 describe('services/pps', () => {
   afterAll(async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
     "module": "commonjs",
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
When this package gets published, it does not do anything special to the paths. That means paths like `lib/types` cannot be resolved outside of this repo's build pipeline. I updated the TS config so this project won't even build if attempting to use a `lib/types` path instead of `../lib/types` going forward. 