### PR TITLE
[FRONT-218] feat(ci): auto publish npm pack on github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,30 @@ jobs:
       - run: etc/testing/circle/start-minikube.sh
       - run: etc/testing/circle/deploy-pachyderm.sh
       - run: pachctl port-forward & npm run test
+  publish:
+    resource_class: xlarge
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - run: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc
+      - run: npm publish
 workflows:
   version: 2
   test:
     jobs:
       - test
+  publish:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /^v.*/
+      - publish:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+

--- a/contributing.md
+++ b/contributing.md
@@ -32,12 +32,10 @@ The linter will also run in CI and fail if there are any stylistic discrepancies
 
 ### Updating protobuf code
 
-Currently, protobuf code is generated in a separate node package [@pachyderm/proto](https://www.npmjs.com/package/@pachyderm/proto?activeTab=dependencies). To update the version of the protos update the dependency in `package.json`.
-```bash
-npm install @pachyderm/proto@{DESIRED_VERSION} --save-exact
-```
-
-Update `version.json` to reference the version of Pachyderm you want to pull. This should match the version of the protos being used in the `package.json`.
+1. Install [jq](https://stedolan.github.io/jq/download/)
+1. Update the pachyderm version in `version.json`
+1. Generate new protos with `npm run build:proto`
+1. Commit the proto updates and merge into main via pull request
 
 ## Testing
 
@@ -80,3 +78,11 @@ npm run opencv
 3. Create a PR
 
 Once your PR is approved, it will be merged into the library.
+
+## Releases and publishing
+
+1. Update the `version` in `package.json`
+1. Update the `version` in `package-lock.json`
+1. Commit the version update and merge into main via pull request
+
+A Pachyderm team member will draft a new release on Github and create a tag, for example v0.19.7. CircleCI will automatically publish the updates to npm once a release is created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.19.5",
+  "version": "0.19.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.19.5",
+      "version": "0.19.7",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",
+        "@types/google-protobuf": "^3.7.4",
         "google-protobuf": "^3.14.0"
       },
       "devDependencies": {
         "@pachyderm/config": "^0.7.0",
-        "@types/google-protobuf": "^3.7.4",
         "@types/jest": "^26.0.15",
         "eslint": "^7.0.0",
         "grpc_tools_node_protoc_ts": "^5.0.1",
@@ -3077,8 +3077,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.5",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
-      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==",
-      "dev": true
+      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -25184,8 +25183,7 @@
     "@types/google-protobuf": {
       "version": "3.15.5",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
-      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==",
-      "dev": true
+      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Using this as a guide: https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/

Once this is merged, I will do a release and make sure everything is publishes correctly. 