### PR TITLE
Always return a new file client.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -129,16 +129,12 @@ const client = ({
       return projectsService;
     },
     modifyFile: () => {
-      if (modifyFile) return modifyFile;
-
-      modifyFile = new ModifyFile({
+      return new ModifyFile({
         pachdAddress,
         channelCredentials,
         credentialMetadata,
         plugins,
       });
-
-      return modifyFile;
     },
     attachCredentials: ({
       authToken = '',

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,7 +70,6 @@ const client = ({
   let ppsService: ReturnType<typeof pps> | undefined;
   let authService: ReturnType<typeof auth> | undefined;
   let projectsService: ReturnType<typeof projects> | undefined;
-  let modifyFile: ModifyFile | undefined;
 
   // NOTE: These service clients are singletons, as we
   // don't want to create a new instance of APIClient for


### PR DESCRIPTION
I ran into this when working on Console tests. We need to always return a new file client. If we reuse the client all uses of it after the initial use will be unusable because the stream will be marked as ended.