### PR TITLE
add max session memory and backoff to putFilesFromBytes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/ModifyFile.ts
+++ b/src/services/ModifyFile.ts
@@ -14,6 +14,9 @@ interface ModifyFileConstructorArgs extends ServiceArgs {
   plugins: GRPCPlugin[];
 }
 
+// We need to account for some overhead in the stream data
+const STREAM_OVERHEAD_LENGTH = 29;
+
 export class ModifyFile {
   private client: APIClient;
   private promise: Promise<Empty.AsObject>;
@@ -68,8 +71,7 @@ export class ModifyFile {
   }
 
   putFileFromBytes(path: string, bytes: Buffer, callback?: () => void) {
-    // We apparently need to account for some overhead in the stream data, using just the full max message length causes an error
-    const messageLength = GRPC_MAX_MESSAGE_LENGTH - 29;
+    const messageLength = GRPC_MAX_MESSAGE_LENGTH - STREAM_OVERHEAD_LENGTH;
     let end = messageLength;
     let chunk = bytes.slice(0, end);
     const write = () => {

--- a/src/services/pfs.ts
+++ b/src/services/pfs.ts
@@ -73,6 +73,7 @@ const pfs = ({
     /* eslint-disable @typescript-eslint/naming-convention */
     'grpc.max_receive_message_length': GRPC_MAX_MESSAGE_LENGTH,
     'grpc.max_send_message_length': GRPC_MAX_MESSAGE_LENGTH,
+    'grpc-node.max_session_memory': 100,
     /* eslint-enable @typescript-eslint/naming-convention */
   });
 


### PR DESCRIPTION
- A ran into an issue with file uploads where the process was running out of memory so I bumped the max session memory from the default of 10MB to 100MB.
- Implements backoff and callback for putFilesFromBytes.