### PR TITLE
Update stream message length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,3 +247,5 @@ export {
   IAPIService_IListProject,
 } from './proto/projects/projects_grpc_pb';
 export * from './proto/projects/projects_pb';
+export {GRPC_MAX_MESSAGE_LENGTH} from './services/pfs/lib/constants';
+export {STREAM_OVERHEAD_LENGTH} from './services/pfs/lib/FileClient';

--- a/src/services/pfs/lib/FileClient.ts
+++ b/src/services/pfs/lib/FileClient.ts
@@ -14,7 +14,7 @@ export interface FileClientConstructorArgs extends ServiceArgs {
 }
 
 // We need to account for some overhead in the stream data
-const STREAM_OVERHEAD_LENGTH = 29;
+const STREAM_OVERHEAD_LENGTH = 17;
 
 export class FileClient<T> {
   protected client: APIClient;
@@ -32,7 +32,8 @@ export class FileClient<T> {
   }
 
   putFileFromBytes(path: string, bytes: Buffer, callback?: () => void) {
-    const messageLength = GRPC_MAX_MESSAGE_LENGTH - STREAM_OVERHEAD_LENGTH;
+    const messageLength =
+      GRPC_MAX_MESSAGE_LENGTH - STREAM_OVERHEAD_LENGTH - path.length;
     const write = (chunk: Buffer, end: number) => {
       if (chunk.length <= 0) {
         if (callback) callback();

--- a/src/services/pfs/lib/FileClient.ts
+++ b/src/services/pfs/lib/FileClient.ts
@@ -13,8 +13,8 @@ export interface FileClientConstructorArgs extends ServiceArgs {
   plugins: GRPCPlugin[];
 }
 
-// We need to account for some overhead in the stream data
-const STREAM_OVERHEAD_LENGTH = 17;
+// We need to account for some overhead in the stream data for putFileFromBytes
+export const STREAM_OVERHEAD_LENGTH = 17;
 
 export class FileClient<T> {
   protected client: APIClient;


### PR DESCRIPTION
The stream overhead for `putFileFromBytes` is not a constant like I previously thought but dependent on the `path` length.