### PR TITLE
Add commit to ModifyFile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/pfs/clients/ModifyFile.ts
+++ b/src/services/pfs/clients/ModifyFile.ts
@@ -9,7 +9,7 @@ import {
 import {deriveObserversFromPlugins} from '../lib/deriverObserversFromPlugins';
 import {FileClient, FileClientConstructorArgs} from '../lib/FileClient';
 export class ModifyFile extends FileClient<Empty.AsObject> {
-  commit: Commit.AsObject;
+  commit: Commit.AsObject | undefined;
   constructor({
     pachdAddress,
     channelCredentials,

--- a/src/services/pfs/clients/ModifyFile.ts
+++ b/src/services/pfs/clients/ModifyFile.ts
@@ -9,6 +9,7 @@ import {
 import {deriveObserversFromPlugins} from '../lib/deriverObserversFromPlugins';
 import {FileClient, FileClientConstructorArgs} from '../lib/FileClient';
 export class ModifyFile extends FileClient<Empty.AsObject> {
+  commit: Commit.AsObject;
   constructor({
     pachdAddress,
     channelCredentials,
@@ -43,15 +44,15 @@ export class ModifyFile extends FileClient<Empty.AsObject> {
   }
 
   autoCommit(branch: BranchObject) {
+    this.commit = new Commit().setBranch(branchFromObject(branch)).toObject();
     this.stream.write(
-      new ModifyFileRequest().setSetCommit(
-        new Commit().setBranch(branchFromObject(branch)),
-      ),
+      new ModifyFileRequest().setSetCommit(commitFromObject(this.commit)),
     );
     return this;
   }
 
   setCommit(commit: Commit.AsObject) {
+    this.commit = commit;
     this.stream.write(
       new ModifyFileRequest().setSetCommit(commitFromObject(commit)),
     );


### PR DESCRIPTION
Some of Console's resolves are required to return the commit ID, so we'll make the commit accessible from 'ModifyFile'