### PR TITLE
Add credentials to fileset operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/pfs/clients/ModifyFile.ts
+++ b/src/services/pfs/clients/ModifyFile.ts
@@ -9,7 +9,6 @@ import {
 import {deriveObserversFromPlugins} from '../lib/deriverObserversFromPlugins';
 import {FileClient, FileClientConstructorArgs} from '../lib/FileClient';
 export class ModifyFile extends FileClient<Empty.AsObject> {
-  commit: Commit.AsObject | undefined;
   constructor({
     pachdAddress,
     channelCredentials,
@@ -44,15 +43,15 @@ export class ModifyFile extends FileClient<Empty.AsObject> {
   }
 
   autoCommit(branch: BranchObject) {
-    this.commit = new Commit().setBranch(branchFromObject(branch)).toObject();
     this.stream.write(
-      new ModifyFileRequest().setSetCommit(commitFromObject(this.commit)),
+      new ModifyFileRequest().setSetCommit(
+        new Commit().setBranch(branchFromObject(branch)),
+      ),
     );
     return this;
   }
 
   setCommit(commit: Commit.AsObject) {
-    this.commit = commit;
     this.stream.write(
       new ModifyFileRequest().setSetCommit(commitFromObject(commit)),
     );

--- a/src/services/pfs/pfs.ts
+++ b/src/services/pfs/pfs.ts
@@ -549,7 +549,7 @@ const pfs = ({
           .setCommit(commitFromObject(commit))
           .setFileSetId(fileSetId);
 
-        client.addFileSet(request, (err) => {
+        client.addFileSet(request, credentialMetadata, (err) => {
           if (err) reject(err);
           else resolve({});
         });
@@ -561,7 +561,7 @@ const pfs = ({
           .setFileSetId(fileSetId)
           .setTtlSeconds(duration);
 
-        client.renewFileSet(request, (err) => {
+        client.renewFileSet(request, credentialMetadata, (err) => {
           if (err) reject(err);
           else resolve({});
         });


### PR DESCRIPTION
Add credentials to fileset calls. The idea of adding the commit to `ModifyFile` doesn't work because the commit id isn't created until the commit starts. Any file operations that require the commit id should user `FileSet`.