### PR TITLE
FRON-513: listCommit default value for all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pachyderm/node-pachyderm",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "Apache License 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachyderm/node-pachyderm",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "node client for pachyderm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/pfs/pfs.ts
+++ b/src/services/pfs/pfs.ts
@@ -179,7 +179,7 @@ const pfs = ({
     },
     listCommit: ({
       number,
-      all = true,
+      all = false,
       originKind,
       from,
       to,


### PR DESCRIPTION
The `all` param for `listCommit` is an override. It should be false by default to allow for filtering by `OriginKind`