### PR TITLE
fix: remove response from pipeline delete

### DIFF
--- a/src/services/pps.ts
+++ b/src/services/pps.ts
@@ -244,11 +244,11 @@ const pps = ({
         client.deletePipeline(
           deletePipelineRequest,
           credentialMetadata,
-          (error, res) => {
+          (error) => {
             if (error) {
               reject(error);
             }
-            return resolve(res.toObject());
+            return resolve({});
           },
         );
       });


### PR DESCRIPTION
This currently causes an error because `res` in `res.toObject()` gets returned as an empty object from the API. 